### PR TITLE
fix: add nginx config to handle SPA client-side routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /usr/share/nginx/html
 # Remover arquivos padrão do NGINX e copiar o build
 RUN rm -rf ./*
 COPY --from=build /app/build .
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
This pull request updates the NGINX configuration for the application Docker image. The main change is the introduction of a custom `nginx.conf` file, which is now copied into the container to replace the default configuration. This ensures that the application serves the frontend correctly, including handling client-side routing for single-page applications.

NGINX configuration improvements:

* Added a custom `nginx.conf` file that defines a server block listening on port 80, sets the root directory, and uses `try_files` to route all requests to `index.html` for proper SPA support.
* Modified the `Dockerfile` to copy the new `nginx.conf` into the container, replacing the default NGINX configuration.